### PR TITLE
feat: implement the endpoints /sessions and /user in order to generate and manage cookies

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,3 +1,5 @@
+import session from "models/session.js";
+import * as cookie from "cookie";
 import {
   InternalServerError,
   MethodNotAllowedError,
@@ -26,12 +28,21 @@ function onErrorHandler(error, request, response) {
 
   response.status(publicErrorObject.statusCode).json(publicErrorObject);
 }
-
+async function setSessionCookie(sessionToken, response) {
+  const setCookie = cookie.serialize("session_id", sessionToken, {
+    path: "/",
+    maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000, // this atribute works in seconds
+    secure: process.env.NODE_ENV === "production" ? true : false,
+    httpOnly: true,
+  });
+  response.setHeader("Set-Cookie", setCookie);
+}
 const controller = {
   errorHandlers: {
     onNoMatch: onNoMatchHandler,
     onError: onErrorHandler,
   },
+  setSessionCookie,
 };
 
 export default controller;

--- a/models/session.js
+++ b/models/session.js
@@ -1,11 +1,13 @@
 import crypto from "node:crypto";
 import database from "infra/database.js";
+import { UnauthorizedError } from "infra/errors";
 const EXPIRATION_IN_MILLISECONDS = 60 * 60 * 24 * 30 * 1000; //30 days
 
 async function create(userId) {
   const token = crypto.randomBytes(48).toString("hex");
   const expires_at = new Date(Date.now() + EXPIRATION_IN_MILLISECONDS);
   const newSession = await runInsertQuery(token, userId, expires_at);
+
   return newSession;
   async function runInsertQuery(token, userId, expiresAt) {
     const results = await database.query({
@@ -20,6 +22,59 @@ async function create(userId) {
     return results.rows[0];
   }
 }
-
-const session = { create, EXPIRATION_IN_MILLISECONDS };
+async function findOneValidByToken(sessionToken) {
+  const results = await runSelectQuery(sessionToken);
+  console.log(results);
+  return results;
+  async function runSelectQuery(sessionToken) {
+    const results = await database.query({
+      text: `SELECT
+                *
+              FROM
+               sessions 
+             WHERE 
+               token = $1
+               AND expires_at > NOW()
+               LIMIT 1
+                ;`,
+      values: [sessionToken],
+    });
+    if (results.rowCount === 0) {
+      const publicError = new UnauthorizedError({
+        message: "Usuário não possui sessão ativa.",
+        action: "verifique se este usuário está logado e tente novamente.",
+      });
+      throw publicError;
+    }
+    return results.rows[0];
+  }
+}
+async function renew(sessionId) {
+  const expiresAt = new Date(Date.now() + EXPIRATION_IN_MILLISECONDS);
+  const renewedSessionObject = await runUpdateQuery(sessionId, expiresAt);
+  return renewedSessionObject;
+  async function runUpdateQuery(sessionId, expiresAt) {
+    const results = await database.query({
+      text: `
+            UPDATE
+              sessions
+            SET
+              expires_at = $2,
+              updated_at = NOW()
+            WHERE
+              id = $1
+            RETURNING
+              *
+            ;`,
+      values: [sessionId, expiresAt],
+    });
+    return results.rows[0];
+  }
+}
+const session = {
+  create,
+  findOneValidByToken,
+  renew,
+  EXPIRATION_IN_MILLISECONDS,
+};
 export default session;

--- a/models/user.js
+++ b/models/user.js
@@ -73,6 +73,31 @@ async function findOnebyEmail(email) {
     return results.rows[0];
   }
 }
+async function findOnebyId(id) {
+  const foundUser = await runSelectQuery(id);
+  return foundUser;
+
+  async function runSelectQuery(id) {
+    const results = await database.query({
+      text: `SELECT 
+              *
+             FROM
+              users
+             WHERE
+              id = $1
+              ;`,
+      values: [id],
+    });
+    if (results.rowCount === 0) {
+      const publicError = new NotFoundError({
+        message: "O id informado não foi encontrado no sistema.",
+        action: "verifique se o id está digitado corretamente.",
+      });
+      throw publicError;
+    }
+    return results.rows[0];
+  }
+}
 async function update(username, userInputValues) {
   const currentUser = await findOnebyUsername(username);
   if ("username" in userInputValues) {
@@ -154,6 +179,7 @@ async function validateUniqueEmail(email) {
     throw publicError;
   }
 }
+
 async function hashPasswordInObject(userInputValues) {
   const hashedPassword = await password.hash(userInputValues.password);
   userInputValues.password = hashedPassword;
@@ -165,6 +191,7 @@ const user = {
   findOnebyUsername,
   findOnebyEmail,
   update,
+  findOnebyId,
 };
 
 export default user;

--- a/pages/api/v1/sessions/index.js
+++ b/pages/api/v1/sessions/index.js
@@ -1,5 +1,4 @@
 import { createRouter } from "next-connect";
-import * as cookie from "cookie";
 import controller from "infra/controller";
 import authentication from "models/authentication.js";
 import session from "models/session.js";
@@ -18,13 +17,7 @@ async function postHandler(request, response) {
   );
 
   const newSession = await session.create(authenticatedUser.id);
-  const setCookie = cookie.serialize("session_id", newSession.token, {
-    path: "/",
-    maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000, // this atribute works in seconds
-    secure: process.env.NODE_ENV === "production" ? true : false,
-    httpOnly: true,
-  });
-  response.setHeader("Set-Cookie", setCookie);
+  controller.setSessionCookie(newSession.token, response);
 
   response.status(201).json(newSession);
 }

--- a/pages/api/v1/user/index.js
+++ b/pages/api/v1/user/index.js
@@ -1,0 +1,18 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import user from "models/user.js";
+import session from "models/session";
+
+const router = createRouter();
+
+export default router.handler(controller.errorHandlers);
+router.get(getHandler);
+
+async function getHandler(request, response) {
+  const sessionToken = request.cookies.session_id;
+  const sessionObject = await session.findOneValidByToken(sessionToken);
+  const renewedSession = await session.renew(sessionObject.id);
+  const userObject = await user.findOnebyId(sessionObject.user_id);
+  controller.setSessionCookie(renewedSession.token, response);
+  response.status(200).json(userObject);
+}

--- a/tests/integration/api/v1/sessions/post.test.js
+++ b/tests/integration/api/v1/sessions/post.test.js
@@ -77,7 +77,7 @@ describe("post api/v1/sessions", () => {
         status_code: 401,
       });
     });
-    test("with correct `email`, but rrect `password`", async () => {
+    test("with correct `email`, but correct `password`", async () => {
       const createdUser = await orchestrator.createUser({
         email: "tudo.correto@gmail.com",
         password: "tudocorreto",
@@ -113,6 +113,7 @@ describe("post api/v1/sessions", () => {
       expiresAt.setMilliseconds(0);
       createdAt.setMilliseconds(0);
       expect(expiresAt - createdAt).toBe(session.EXPIRATION_IN_MILLISECONDS);
+
       const parsedSetCookie = setCookieParser(response, { map: true });
       expect(parsedSetCookie.session_id).toEqual({
         name: "session_id",

--- a/tests/integration/api/v1/user/get.test.js
+++ b/tests/integration/api/v1/user/get.test.js
@@ -1,0 +1,105 @@
+import session from "models/session";
+import orchestrator from "tests/orchestrator.js";
+import setCookieParser from "set-cookie-parser";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDataBase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("GET api/v1/user", () => {
+  describe("Default user", () => {
+    test("with valid session", async () => {
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithValidSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      const response = await fetch("http://localhost:3000/api/v1/user", {
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        id: createdUser.id,
+        username: "UserWithValidSession",
+        email: createdUser.email,
+        password: createdUser.password,
+        created_at: createdUser.created_at.toISOString(), //toISOString() change from object to string
+        updated_at: createdUser.updated_at.toISOString(),
+      });
+      //Session renewal assertions
+      const renewedSessionObject = await session.findOneValidByToken(
+        sessionObject.token,
+      );
+
+      expect(
+        renewedSessionObject.expires_at > sessionObject.expires_at,
+      ).toEqual(true);
+      expect(
+        renewedSessionObject.updated_at > sessionObject.updated_at,
+      ).toEqual(true);
+      //Set-cookie assertions
+      const parsedSetCookie = setCookieParser(response, { map: true });
+      expect(parsedSetCookie.session_id).toEqual({
+        name: "session_id",
+        value: sessionObject.token,
+        maxAge: session.EXPIRATION_IN_MILLISECONDS / 1000,
+        path: "/",
+        httpOnly: true,
+      });
+    });
+    test("with nonexistent session", async () => {
+      const nonexistentToken =
+        "43e9accf27decab382f83d6dfad671c25def1924465ada19dd0cfd2aa1bcdefdb349d88600ab83b166545ade81e0f479";
+
+      const response = await fetch("http://localhost:3000/api/v1/user", {
+        headers: {
+          Cookie: `session_id=${nonexistentToken}`,
+        },
+      });
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+    test("with expired session", async () => {
+      jest.useFakeTimers({
+        now: new Date(Date.now() - session.EXPIRATION_IN_MILLISECONDS),
+      });
+
+      const createdUser = await orchestrator.createUser({
+        username: "UserWithExpiredSession",
+      });
+
+      const sessionObject = await orchestrator.createSession(createdUser.id);
+
+      jest.useRealTimers();
+
+      const response = await fetch("http://localhost:3000/api/v1/user", {
+        headers: {
+          Cookie: `session_id=${sessionObject.token}`,
+        },
+      });
+      expect(response.status).toBe(401);
+
+      const responseBody = await response.json();
+      expect(responseBody).toEqual({
+        name: "UnauthorizedError",
+        message: "Usuário não possui sessão ativa.",
+        action: "verifique se este usuário está logado e tente novamente.",
+        status_code: 401,
+      });
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -3,6 +3,7 @@ import { faker } from "@faker-js/faker/.";
 import database from "infra/database.js";
 import migrator from "models/migrator.js";
 import user from "models/user.js";
+import session from "models/session.js";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -38,11 +39,16 @@ async function createUser(userObject) {
   });
 }
 
+async function createSession(userId) {
+  return session.create(userId);
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDataBase,
   runPendingMigrations,
   createUser,
+  createSession,
 };
 
 export default orchestrator;


### PR DESCRIPTION
here is implemented to endpoints: /user and /session. The first one is used to renew the session and to get the user data and the second one is used to generate the session 